### PR TITLE
Add ulimit support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ The option `--memory` does the same for memory usage. On Debian machines, this
 requires the kernel parameters `cgroup_enable=memory swapaccount=1`. Returns 24
 when OOM occurs.
 
+The option `--ulimit` sets ulimits for the container and expects a key-value pair
+separated by an equal sign (`=`). This option can be specified multiple times.
+
 Not much is expected from the docker image. But some programs do not like it
 when the current user id has no name (e.g. those using `whoami`). If you need
 to run these, you need to add the user to your image’s `/etc/passwd`, and

--- a/safe-docker
+++ b/safe-docker
@@ -14,12 +14,14 @@ my $image = 'safe-docker';
 my @dirs = ();
 my $timeout = 60;
 my $maxmemory = "1G";
+my $ulimits = ();
 
 GetOptions (
 #	"image=s" => \$image,
 	"dir=s" => \@dirs,
 	"timeout=i" => \$timeout,
 	"memory=s" => \$maxmemory,
+	'ulimit=s' => \@ulimits,
 	)
 or die("Error in command line arguments\n");
 
@@ -47,6 +49,7 @@ for (@dirs) {
 my @cmd;
 push @cmd, qw!docker run --rm --read-only --sig-proxy --tmpfs /tmp --tmpfs /run --tmpfs /home --net=none!;
 push @cmd, (sprintf "--memory=%s", $maxmemory);
+push @cmd, (sprintf "--ulimit=%s", $_) for @ulimits;
 push @cmd, (sprintf "--user=%d:%d", $uid, $gid);
 push @cmd, (sprintf "--volume=%s:%s:ro", $_, $_) for @dirs;
 push @cmd, (sprintf "--volume=%s:%s", $cwd, $cwd);


### PR DESCRIPTION
This allows setting ulimits for a container using safe-docker. See https://docs.docker.com/engine/reference/commandline/run/#set-ulimits-in-container---ulimit for the corresponding Docker CLI documentation.